### PR TITLE
Update for new pymt release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,17 +20,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9]
+        python-version: ["3.11"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-update-conda: true
+          miniforge-version: latest
           python-version: ${{ matrix.python-version }}
-          channels: conda-forge
-          channel-priority: true
 
       - name: Show conda installation info
         run: |
@@ -39,16 +37,12 @@ jobs:
 
       - name: Install requirements
         run: |
-          conda install mamba
-          mamba install --file=requirements-build.txt --file=requirements-library.txt
-          mamba list
+          conda install --file=requirements-build.txt --file=requirements-library.txt --file=requirements-testing.txt
+          conda list
 
       - name: Build and install package
         run: |
           pip install -e .
-
-      - name: Install testing dependencies
-        run: mamba install --file=requirements-testing.txt
 
       - name: Test
         run: |

--- a/meta/Roms/parameters.yaml
+++ b/meta/Roms/parameters.yaml
@@ -4,7 +4,6 @@ filename:
   value:
     type: string
     default: 'https://tds.marine.rutgers.edu/thredds/dodsC/roms/doppio/2017_da/avg/runs/Averages_RUN_2023-03-31T00:00:00Z?s_rho[0:1:39],lon_rho[0:1:105][0:1:241],lat_rho[0:1:105][0:1:241],ocean_time[0:1:0],time[0:1:5],zeta[0:1:5][0:1:105][0:1:241],salt[0:1:5][0:1:39][0:1:105][0:1:241]'
-    units: 1
 
 download:
   name: Download data
@@ -12,4 +11,3 @@ download:
   value:
     type: bool
     default: False
-    units: 1

--- a/pymt_roms/bmi.py
+++ b/pymt_roms/bmi.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import pkg_resources
-
 from bmi_roms import BmiRoms as Roms
 
 Roms.__name__ = "Roms"


### PR DESCRIPTION
This PR includes a few minor changes to help *pymt_roms* work with the new *pymt* release, v1.3.2. This includes:

* Updating `meta/Roms/parameters.yaml` to work with the latest *model_metadata*, v0.8.2.
* Using *miniforge* in the test CI workflow. (This will eventually get updated in the *babelizer*.) Also running the workflow with Python 3.11.